### PR TITLE
SEM-58 Add list with possible subjectchoices for next year

### DIFF
--- a/reference/sisdata.v1.yaml
+++ b/reference/sisdata.v1.yaml
@@ -342,6 +342,13 @@ components:
       required:
         - id
         - schoolSubjectName
+    subject-choices:
+      type: array
+      items:
+        $ref: '#/components/schemas/subject-choice'
+      x-tags:
+        - subject-choice
+      description: List of possible subject choices
     student-delivery:
       title: student-delivery
       type: object
@@ -499,6 +506,29 @@ paths:
       security:
         - APIKey:
             - sis.student-teacher-delivery
+  /subjectchoices:
+    parameters: []
+    get:
+      summary: GET Subject choices for next years
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/subject-choices'
+      operationId: get-subjectchoices-schoolyear
+      security:
+        - APIKey:
+            - sis.student-teacher-group
+      description: Get possible subject choices for next schoolyears. User to create LML lists in MP while exact student / subjectchoices re not available
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: schoolYear
+          description: request this list for a particular schoolyear
 tags:
   - name: group
   - name: student


### PR DESCRIPTION
For next year the MP would like to know the possible subject choices for next year to create Leermiddel lijsten.
The details about which student follows which studies and choices is not yet known at that point (april-may). Creating LML cant wait until august, so we need an additional call to get subject choices in a school for next year.